### PR TITLE
[Fix] `administration_id` should always be a string

### DIFF
--- a/docs/src/content/docs/reference/contacts.md
+++ b/docs/src/content/docs/reference/contacts.md
@@ -245,7 +245,7 @@ When working with contacts, you'll have access to the following properties:
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier |
-| administration_id | integer | Administration ID |
+| administration_id | string | Administration ID |
 | company_name | string | Company name |
 | firstname | string | First name |
 | lastname | string | Last name |

--- a/docs/src/content/docs/reference/external-sales-invoice-payments.md
+++ b/docs/src/content/docs/reference/external-sales-invoice-payments.md
@@ -54,7 +54,7 @@ When working with external sales invoice payments, you'll have access to the fol
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier for the payment |
-| administration_id | int | ID of the administration the payment belongs to |
+| administration_id | string | ID of the administration the payment belongs to |
 | invoice_type | string | Type of invoice (always "ExternalSalesInvoice" for these payments) |
 | invoice_id | string | ID of the external sales invoice the payment is for |
 | financial_account_id | string | ID of the financial account the payment was made to |

--- a/docs/src/content/docs/reference/external-sales-invoices.md
+++ b/docs/src/content/docs/reference/external-sales-invoices.md
@@ -136,7 +136,7 @@ When working with external sales invoices, you'll have access to the following p
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier |
-| administration_id | integer | ID of the administration the invoice belongs to |
+| administration_id | string | ID of the administration the invoice belongs to |
 | contact_id | string | ID of the contact associated with the invoice |
 | contact | array | Contact details |
 | date | string | Date of the invoice (YYYY-MM-DD) |

--- a/docs/src/content/docs/reference/sales-invoices.md
+++ b/docs/src/content/docs/reference/sales-invoices.md
@@ -273,7 +273,7 @@ When working with sales invoices, you'll have access to the following properties
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier |
-| administration_id | int | ID of the administration the sales invoice belongs to |
+| administration_id | string | ID of the administration the sales invoice belongs to |
 | contact_id | string | ID of the contact associated with the sales invoice |
 | contact | array | Contact information |
 | contact_person_id | string | ID of the contact person |
@@ -297,36 +297,36 @@ When working with sales invoices, you'll have access to the following properties
 | discount | string | Discount percentage |
 | original_sales_invoice_id | string | ID of the original sales invoice if this is a duplicate |
 | paused | boolean | Whether the invoice is paused |
-| paid_at | string | Date when the invoice was paid |
-| sent_at | string | Date when the invoice was sent |
-| created_at | string | ISO 8601 timestamp of when the sales invoice was created |
-| updated_at | string | ISO 8601 timestamp of when the sales invoice was last updated |
-| public_view_code | string | Code for public view access |
-| public_view_code_expires_at | string | Expiration date for public view code |
-| version | int | Version number |
-| details | array | Line items on the sales invoice |
-| payments | array | Payment information |
-| total_paid | string | Total amount paid |
-| total_unpaid | string | Total amount unpaid |
-| total_unpaid_base | string | Total amount unpaid in base currency |
+| paid_at | string  | Date when the invoice was paid |
+| sent_at | string  | Date when the invoice was sent |
+| created_at | string  | ISO 8601 timestamp of when the sales invoice was created |
+| updated_at | string  | ISO 8601 timestamp of when the sales invoice was last updated |
+| public_view_code | string  | Code for public view access |
+| public_view_code_expires_at | string  | Expiration date for public view code |
+| version | int     | Version number |
+| details | array   | Line items on the sales invoice |
+| payments | array   | Payment information |
+| total_paid | string  | Total amount paid |
+| total_unpaid | string  | Total amount unpaid |
+| total_unpaid_base | string  | Total amount unpaid in base currency |
 | prices_are_incl_tax | boolean | Whether prices include tax |
-| total_price_excl_tax | string | Total price excluding tax |
-| total_price_excl_tax_base | string | Total price excluding tax in base currency |
-| total_price_incl_tax | string | Total price including tax |
-| total_price_incl_tax_base | string | Total price including tax in base currency |
-| total_discount | string | Total discount amount |
-| marked_dubious_on | string | Date when marked as dubious |
-| marked_uncollectible_on | string | Date when marked as uncollectible |
-| reminder_count | int | Number of reminders sent |
-| next_reminder | string | Date of the next reminder |
-| original_estimate_id | string | ID of the original estimate if created from one |
-| url | string | URL to view the invoice |
-| payment_url | string | URL for payment |
-| custom_fields | array | Custom fields for the sales invoice |
-| notes | array | Notes associated with the sales invoice |
-| attachments | array | Attachments associated with the sales invoice |
-| events | array | Events related to the sales invoice |
-| tax_totals | array | Tax totals information |
+| total_price_excl_tax | string  | Total price excluding tax |
+| total_price_excl_tax_base | string  | Total price excluding tax in base currency |
+| total_price_incl_tax | string  | Total price including tax |
+| total_price_incl_tax_base | string  | Total price including tax in base currency |
+| total_discount | string  | Total discount amount |
+| marked_dubious_on | string  | Date when marked as dubious |
+| marked_uncollectible_on | string  | Date when marked as uncollectible |
+| reminder_count | int     | Number of reminders sent |
+| next_reminder | string  | Date of the next reminder |
+| original_estimate_id | string  | ID of the original estimate if created from one |
+| url | string  | URL to view the invoice |
+| payment_url | string  | URL for payment |
+| custom_fields | array   | Custom fields for the sales invoice |
+| notes | array   | Notes associated with the sales invoice |
+| attachments | array   | Attachments associated with the sales invoice |
+| events | array   | Events related to the sales invoice |
+| tax_totals | array   | Tax totals information |
 
 > **Note:** See the [official API reference](https://developer.moneybird.com/api/sales_invoices/) for the complete list of available properties.
 

--- a/docs/src/content/docs/reference/sales-invoices.md
+++ b/docs/src/content/docs/reference/sales-invoices.md
@@ -297,36 +297,36 @@ When working with sales invoices, you'll have access to the following properties
 | discount | string | Discount percentage |
 | original_sales_invoice_id | string | ID of the original sales invoice if this is a duplicate |
 | paused | boolean | Whether the invoice is paused |
-| paid_at | string  | Date when the invoice was paid |
-| sent_at | string  | Date when the invoice was sent |
-| created_at | string  | ISO 8601 timestamp of when the sales invoice was created |
-| updated_at | string  | ISO 8601 timestamp of when the sales invoice was last updated |
-| public_view_code | string  | Code for public view access |
-| public_view_code_expires_at | string  | Expiration date for public view code |
-| version | int     | Version number |
-| details | array   | Line items on the sales invoice |
-| payments | array   | Payment information |
-| total_paid | string  | Total amount paid |
-| total_unpaid | string  | Total amount unpaid |
-| total_unpaid_base | string  | Total amount unpaid in base currency |
+| paid_at | string | Date when the invoice was paid |
+| sent_at | string | Date when the invoice was sent |
+| created_at | string | ISO 8601 timestamp of when the sales invoice was created |
+| updated_at | string | ISO 8601 timestamp of when the sales invoice was last updated |
+| public_view_code | string | Code for public view access |
+| public_view_code_expires_at | string | Expiration date for public view code |
+| version | int | Version number |
+| details | array | Line items on the sales invoice |
+| payments | array | Payment information |
+| total_paid | string | Total amount paid |
+| total_unpaid | string | Total amount unpaid |
+| total_unpaid_base | string | Total amount unpaid in base currency |
 | prices_are_incl_tax | boolean | Whether prices include tax |
-| total_price_excl_tax | string  | Total price excluding tax |
-| total_price_excl_tax_base | string  | Total price excluding tax in base currency |
-| total_price_incl_tax | string  | Total price including tax |
-| total_price_incl_tax_base | string  | Total price including tax in base currency |
-| total_discount | string  | Total discount amount |
-| marked_dubious_on | string  | Date when marked as dubious |
-| marked_uncollectible_on | string  | Date when marked as uncollectible |
-| reminder_count | int     | Number of reminders sent |
-| next_reminder | string  | Date of the next reminder |
-| original_estimate_id | string  | ID of the original estimate if created from one |
-| url | string  | URL to view the invoice |
-| payment_url | string  | URL for payment |
-| custom_fields | array   | Custom fields for the sales invoice |
-| notes | array   | Notes associated with the sales invoice |
-| attachments | array   | Attachments associated with the sales invoice |
-| events | array   | Events related to the sales invoice |
-| tax_totals | array   | Tax totals information |
+| total_price_excl_tax | string | Total price excluding tax |
+| total_price_excl_tax_base | string | Total price excluding tax in base currency |
+| total_price_incl_tax | string | Total price including tax |
+| total_price_incl_tax_base | string | Total price including tax in base currency |
+| total_discount | string | Total discount amount |
+| marked_dubious_on | string | Date when marked as dubious |
+| marked_uncollectible_on | string | Date when marked as uncollectible |
+| reminder_count | int | Number of reminders sent |
+| next_reminder | string | Date of the next reminder |
+| original_estimate_id | string | ID of the original estimate if created from one |
+| url | string | URL to view the invoice |
+| payment_url | string | URL for payment |
+| custom_fields | array | Custom fields for the sales invoice |
+| notes | array | Notes associated with the sales invoice |
+| attachments | array | Attachments associated with the sales invoice |
+| events | array | Events related to the sales invoice |
+| tax_totals | array | Tax totals information |
 
 > **Note:** See the [official API reference](https://developer.moneybird.com/api/sales_invoices/) for the complete list of available properties.
 

--- a/docs/src/content/docs/reference/subscription-templates.md
+++ b/docs/src/content/docs/reference/subscription-templates.md
@@ -86,7 +86,7 @@ When working with subscription templates, you'll have access to the following pr
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier |
-| administration_id | int | ID of the administration the template belongs to |
+| administration_id | string | ID of the administration the template belongs to |
 | workflow_id | string | ID of the workflow to use for the subscription |
 | document_style_id | string | ID of the document style |
 | mergeable | boolean | Whether the template can be merged with other templates |

--- a/docs/src/content/docs/reference/subscriptions.md
+++ b/docs/src/content/docs/reference/subscriptions.md
@@ -111,7 +111,7 @@ When working with subscriptions, you'll have access to the following properties:
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier |
-| administration_id | int | ID of the administration the subscription belongs to |
+| administration_id | string | ID of the administration the subscription belongs to |
 | start_date | string | Date when the subscription starts |
 | end_date | string | Date when the subscription ends (null if ongoing) |
 | frequency | int | Frequency number (e.g., 1, 3, 6) |

--- a/docs/src/content/docs/reference/tax-rates.md
+++ b/docs/src/content/docs/reference/tax-rates.md
@@ -46,7 +46,7 @@ When working with tax rates, you'll have access to the following properties:
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier |
-| administration_id | int | ID of the administration the tax rate belongs to |
+| administration_id | string | ID of the administration the tax rate belongs to |
 | name | string | Name of the tax rate (e.g., "21% btw") |
 | percentage | string | Tax percentage value (e.g., "21.0") |
 | tax_rate_type | string | Type of tax rate (e.g., "sales_invoice") |

--- a/docs/src/content/docs/reference/time-entries.md
+++ b/docs/src/content/docs/reference/time-entries.md
@@ -95,7 +95,7 @@ When working with time entries, you'll have access to the following properties:
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier |
-| administration_id | int | ID of the administration the time entry belongs to |
+| administration_id | string | ID of the administration the time entry belongs to |
 | contact_id | string | ID of the contact associated with the time entry (optional) |
 | project_id | string | ID of the project associated with the time entry (optional) |
 | user_id | int | ID of the user who created the time entry |

--- a/docs/src/content/docs/reference/webhooks.md
+++ b/docs/src/content/docs/reference/webhooks.md
@@ -31,7 +31,7 @@ When working with webhooks, you'll have access to the following properties:
 | Property | Type | Description |
 |----------|------|-------------|
 | id | string | Unique identifier for the webhook |
-| administration_id | int | ID of the administration the webhook belongs to |
+| administration_id | string | ID of the administration the webhook belongs to |
 | url | string | URL that will receive the webhook notifications |
 | enabled_events | array | List of events the webhook is subscribed to |
 | last_http_status | int | Last HTTP status code received when delivering the webhook |

--- a/src/Api/Contacts/Contact.php
+++ b/src/Api/Contacts/Contact.php
@@ -8,7 +8,7 @@ class Contact extends BaseDto
 {
     public string $id;
 
-    public int $administration_id;
+    public string $administration_id;
 
     public ?string $company_name;
 

--- a/src/Api/ExternalSalesInvoices/ExternalSalesInvoice.php
+++ b/src/Api/ExternalSalesInvoices/ExternalSalesInvoice.php
@@ -10,7 +10,7 @@ class ExternalSalesInvoice extends BaseDto
 {
     public string $id;
 
-    public int $administration_id;
+    public string $administration_id;
 
     public string $contact_id;
 

--- a/src/Api/ExternalSalesInvoices/Payments/ExternalSalesInvoicePayment.php
+++ b/src/Api/ExternalSalesInvoices/Payments/ExternalSalesInvoicePayment.php
@@ -10,7 +10,7 @@ class ExternalSalesInvoicePayment extends BaseDto
 {
     public string $id;
 
-    public int $administration_id;
+    public string $administration_id;
 
     public string $invoice_type;
 

--- a/src/Api/SalesInvoices/SalesInvoice.php
+++ b/src/Api/SalesInvoices/SalesInvoice.php
@@ -10,7 +10,7 @@ class SalesInvoice extends BaseDto
 {
     public string $id;
 
-    public int $administration_id;
+    public string $administration_id;
 
     public string $contact_id;
 

--- a/src/Api/Webhooks/Webhook.php
+++ b/src/Api/Webhooks/Webhook.php
@@ -10,7 +10,7 @@ class Webhook extends BaseDto
 {
     public string $id;
 
-    public int $administration_id;
+    public string $administration_id;
 
     public string $url;
 

--- a/tests/Api/Contacts/ContactResponseStub.php
+++ b/tests/Api/Contacts/ContactResponseStub.php
@@ -10,7 +10,7 @@ class ContactResponseStub
     {
         return [
             'id' => '419889276175517682',
-            'administration_id' => 123,
+            'administration_id' => '123',
             'company_name' => 'Sandorian Consultancy B.V.',
             'firstname' => null,
             'lastname' => 'Appleseed',

--- a/tests/Api/ExternalSalesInvoices/ExternalSalesInvoiceResponseStub.php
+++ b/tests/Api/ExternalSalesInvoices/ExternalSalesInvoiceResponseStub.php
@@ -10,7 +10,7 @@ class ExternalSalesInvoiceResponseStub
     {
         return [
             'id' => '426664163463398887',
-            'administration_id' => 123,
+            'administration_id' => '123',
             'contact_id' => '426664163441378788',
             'contact' => [
                 'id' => '426664163441378788',

--- a/tests/Api/ExternalSalesInvoices/Payments/ExternalSalesInvoicePaymentResponseStub.php
+++ b/tests/Api/ExternalSalesInvoices/Payments/ExternalSalesInvoicePaymentResponseStub.php
@@ -10,7 +10,7 @@ class ExternalSalesInvoicePaymentResponseStub
     {
         return [
             'id' => '426664167809746572',
-            'administration_id' => 123,
+            'administration_id' => '123',
             'invoice_type' => 'ExternalSalesInvoice',
             'invoice_id' => '426664167757317770',
             'financial_account_id' => null,

--- a/tests/Api/SalesInvoices/SalesInvoiceResponseStub.php
+++ b/tests/Api/SalesInvoices/SalesInvoiceResponseStub.php
@@ -10,7 +10,7 @@ class SalesInvoiceResponseStub
     {
         return [
             'id' => '446241800938587778',
-            'administration_id' => 123,
+            'administration_id' => '123',
             'contact_id' => '446241800633452147',
             'contact' => [
                 'id' => '446241800633452147',

--- a/tests/Api/Webhooks/WebhooksEndpointTest.php
+++ b/tests/Api/Webhooks/WebhooksEndpointTest.php
@@ -16,7 +16,7 @@ class WebhooksEndpointTest extends BaseTestCase
         $moneybird = $this->getMoneybirdClientWithMocks([
             CreateWebhookRequest::class => MockResponse::make([
                 'id' => '426664308573734088',
-                'administration_id' => 123,
+                'administration_id' => '123',
                 'url' => 'http://www.mocky.io/v2/5185415ba171ea3a00704eed',
                 'events' => [],
                 'last_http_status' => null,


### PR DESCRIPTION
This seems to be inconsistent right now. Some DTO's have `administration_id` set to string and some to integer. The moneybird documentation seems to clearly state that all administration_id's are strings. See the [documentation for administration endpoints](https://developer.moneybird.com/api/administration/#get_version_administrations) for example.

Also, making the following call:

```
$contact = $moneybirdApiClient->contacts()->create([
  'contact' => [
        'company_name' => 'Acme Corporation',
    ]
]);
```

Produces the following error:

```
ERROR: Cannot assign string to property Sandorian\Moneybird\Api\Contacts\Contact::$administration_id of type int
```

I checked all Dto's to make sure no administration_ids are seen as integers anymore. 

Please let me know if there is anything more I can do!