### PR TITLE
Cleanup endpoints

### DIFF
--- a/src/Api/Contacts/AdditionalCharges/CreateAdditionalChargeRequest.php
+++ b/src/Api/Contacts/AdditionalCharges/CreateAdditionalChargeRequest.php
@@ -11,8 +11,11 @@ class CreateAdditionalChargeRequest extends BaseJsonPostRequest
 {
     public function __construct(
         protected readonly string $contactId,
+        private readonly array $data = []
     ) {
-        //
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
     }
 
     public function resolveEndpoint(): string

--- a/src/Api/Contacts/ContactPeople/CreateContactPersonRequest.php
+++ b/src/Api/Contacts/ContactPeople/CreateContactPersonRequest.php
@@ -11,8 +11,11 @@ class CreateContactPersonRequest extends BaseJsonPostRequest
 {
     public function __construct(
         protected readonly string $contactId,
+        private readonly array $data = []
     ) {
-        //
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
     }
 
     public function resolveEndpoint(): string

--- a/src/Api/Contacts/ContactPeople/UpdateContactPersonRequest.php
+++ b/src/Api/Contacts/ContactPeople/UpdateContactPersonRequest.php
@@ -12,8 +12,11 @@ class UpdateContactPersonRequest extends BaseJsonPatchRequest
     public function __construct(
         protected readonly string $contactId,
         protected readonly string $contactPersonId,
+        private readonly array $data = []
     ) {
-        //
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
     }
 
     public function resolveEndpoint(): string

--- a/src/Api/Contacts/ContactsEndpoint.php
+++ b/src/Api/Contacts/ContactsEndpoint.php
@@ -68,8 +68,7 @@ class ContactsEndpoint extends BaseEndpoint
 
     public function update(string $contactId, array $data): Contact
     {
-        $request = new UpdateContactRequest($contactId);
-        $request->setEncapsulatedData($data);
+        $request = new UpdateContactRequest($contactId, $data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -85,8 +84,7 @@ class ContactsEndpoint extends BaseEndpoint
 
     public function createAdditionalCharge(string $contactId, array $data): AdditionalCharge
     {
-        $request = new CreateAdditionalChargeRequest($contactId);
-        $request->setEncapsulatedData($data);
+        $request = new CreateAdditionalChargeRequest($contactId, $data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -105,8 +103,7 @@ class ContactsEndpoint extends BaseEndpoint
 
     public function createNote(string $contactId, array $data): Note
     {
-        $request = new CreateNoteRequest($contactId);
-        $request->setEncapsulatedData($data);
+        $request = new CreateNoteRequest($contactId, $data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -129,16 +126,14 @@ class ContactsEndpoint extends BaseEndpoint
 
     public function createContactPerson(string $contactId, array $data): ContactPerson
     {
-        $request = new CreateContactPersonRequest($contactId);
-        $request->setEncapsulatedData($data);
+        $request = new CreateContactPersonRequest($contactId, $data);
 
         return $this->client->send($request)->dtoOrFail();
     }
 
     public function updateContactPerson(string $contactId, string $contactPersonId, array $data): ContactPerson
     {
-        $request = new UpdateContactPersonRequest($contactId, $contactPersonId);
-        $request->setEncapsulatedData($data);
+        $request = new UpdateContactPersonRequest($contactId, $contactPersonId, $data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -161,8 +156,7 @@ class ContactsEndpoint extends BaseEndpoint
 
     public function createMbPaymentsMandate(string $contactId, array $data = []): MbPaymentsMandate
     {
-        $request = new CreateMbPaymentsMandateRequest($contactId);
-        $request->setEncapsulatedData($data);
+        $request = new CreateMbPaymentsMandateRequest($contactId, $data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -186,6 +180,7 @@ class ContactsEndpoint extends BaseEndpoint
     {
         $request = new CreateContactRequest;
         $request->setEncapsulatedData($data);
+
         return $request;
     }
 

--- a/src/Api/Contacts/ContactsEndpoint.php
+++ b/src/Api/Contacts/ContactsEndpoint.php
@@ -86,11 +86,7 @@ class ContactsEndpoint extends BaseEndpoint
     public function createAdditionalCharge(string $contactId, array $data): AdditionalCharge
     {
         $request = new CreateAdditionalChargeRequest($contactId);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
+        $request->setEncapsulatedData($data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -110,11 +106,7 @@ class ContactsEndpoint extends BaseEndpoint
     public function createNote(string $contactId, array $data): Note
     {
         $request = new CreateNoteRequest($contactId);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
+        $request->setEncapsulatedData($data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -138,11 +130,7 @@ class ContactsEndpoint extends BaseEndpoint
     public function createContactPerson(string $contactId, array $data): ContactPerson
     {
         $request = new CreateContactPersonRequest($contactId);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
+        $request->setEncapsulatedData($data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -150,11 +138,7 @@ class ContactsEndpoint extends BaseEndpoint
     public function updateContactPerson(string $contactId, string $contactPersonId, array $data): ContactPerson
     {
         $request = new UpdateContactPersonRequest($contactId, $contactPersonId);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
+        $request->setEncapsulatedData($data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -178,13 +162,7 @@ class ContactsEndpoint extends BaseEndpoint
     public function createMbPaymentsMandate(string $contactId, array $data = []): MbPaymentsMandate
     {
         $request = new CreateMbPaymentsMandateRequest($contactId);
-        if (! empty($data)) {
-            if (method_exists($request, 'setEncapsulatedData')) {
-                $request->setEncapsulatedData($data);
-            } else {
-                $request->body()->merge($data);
-            }
-        }
+        $request->setEncapsulatedData($data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -192,13 +170,7 @@ class ContactsEndpoint extends BaseEndpoint
     public function createMbPaymentsMandateUrl(string $contactId, array $data = []): MbPaymentsMandateUrl
     {
         $request = new CreateMbPaymentsMandateUrlRequest($contactId);
-        if (! empty($data)) {
-            if (method_exists($request, 'setEncapsulatedData')) {
-                $request->setEncapsulatedData($data);
-            } else {
-                $request->body()->merge($data);
-            }
-        }
+        $request->setEncapsulatedData($data);
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/Contacts/ContactsEndpoint.php
+++ b/src/Api/Contacts/ContactsEndpoint.php
@@ -182,9 +182,11 @@ class ContactsEndpoint extends BaseEndpoint
         $this->client->send($request);
     }
 
-    protected function getCreateRequest(): CreateContactRequest
+    protected function getCreateRequest(array $data = []): CreateContactRequest
     {
-        return new CreateContactRequest;
+        $request = new CreateContactRequest;
+        $request->setEncapsulatedData($data);
+        return $request;
     }
 
     protected function getPaginateRequest(): GetContactsPageRequest

--- a/src/Api/Contacts/ContactsEndpoint.php
+++ b/src/Api/Contacts/ContactsEndpoint.php
@@ -163,8 +163,7 @@ class ContactsEndpoint extends BaseEndpoint
 
     public function createMbPaymentsMandateUrl(string $contactId, array $data = []): MbPaymentsMandateUrl
     {
-        $request = new CreateMbPaymentsMandateUrlRequest($contactId);
-        $request->setEncapsulatedData($data);
+        $request = new CreateMbPaymentsMandateUrlRequest($contactId, $data);
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -178,10 +177,7 @@ class ContactsEndpoint extends BaseEndpoint
 
     protected function getCreateRequest(array $data = []): CreateContactRequest
     {
-        $request = new CreateContactRequest;
-        $request->setEncapsulatedData($data);
-
-        return $request;
+        return new CreateContactRequest($data);
     }
 
     protected function getPaginateRequest(): GetContactsPageRequest

--- a/src/Api/Contacts/CreateContactRequest.php
+++ b/src/Api/Contacts/CreateContactRequest.php
@@ -9,6 +9,14 @@ use Sandorian\Moneybird\Api\Support\BaseJsonPostRequest;
 
 class CreateContactRequest extends BaseJsonPostRequest
 {
+    public function __construct(
+        private readonly array $data = []
+    ) {
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
+    }
+
     public function resolveEndpoint(): string
     {
         return 'contacts';

--- a/src/Api/Contacts/MbPaymentsMandate/CreateMbPaymentsMandateRequest.php
+++ b/src/Api/Contacts/MbPaymentsMandate/CreateMbPaymentsMandateRequest.php
@@ -17,8 +17,11 @@ class CreateMbPaymentsMandateRequest extends BaseJsonPostRequest
      */
     public function __construct(
         protected readonly string $contactId,
+        private readonly array $data = []
     ) {
-        //
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
     }
 
     public function resolveEndpoint(): string

--- a/src/Api/Contacts/MbPaymentsMandate/CreateMbPaymentsMandateUrlRequest.php
+++ b/src/Api/Contacts/MbPaymentsMandate/CreateMbPaymentsMandateUrlRequest.php
@@ -17,8 +17,11 @@ class CreateMbPaymentsMandateUrlRequest extends BaseJsonPostRequest
      */
     public function __construct(
         protected readonly string $contactId,
+        private readonly array $data = []
     ) {
-        //
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
     }
 
     public function resolveEndpoint(): string

--- a/src/Api/Contacts/Notes/CreateNoteRequest.php
+++ b/src/Api/Contacts/Notes/CreateNoteRequest.php
@@ -17,8 +17,11 @@ class CreateNoteRequest extends BaseJsonPostRequest
      */
     public function __construct(
         protected readonly string $contactId,
+        private readonly array $data = []
     ) {
-        //
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
     }
 
     public function resolveEndpoint(): string

--- a/src/Api/Contacts/UpdateContactRequest.php
+++ b/src/Api/Contacts/UpdateContactRequest.php
@@ -10,8 +10,13 @@ use Sandorian\Moneybird\Api\Support\BaseJsonPatchRequest;
 class UpdateContactRequest extends BaseJsonPatchRequest
 {
     public function __construct(
-        private readonly string $contactId
-    ) {}
+        private readonly string $contactId,
+        private readonly array $data = []
+    ) {
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
+    }
 
     public function resolveEndpoint(): string
     {

--- a/src/Api/Documents/GeneralDocuments/GeneralDocumentsEndpoint.php
+++ b/src/Api/Documents/GeneralDocuments/GeneralDocumentsEndpoint.php
@@ -66,12 +66,6 @@ class GeneralDocumentsEndpoint extends BaseEndpoint
     {
         $request = new CreateGeneralDocumentRequest($generalDocumentData);
 
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($generalDocumentData);
-        } else {
-            $request->body()->merge($generalDocumentData);
-        }
-
         return $this->client->send($request)->dtoOrFail();
     }
 
@@ -81,12 +75,6 @@ class GeneralDocumentsEndpoint extends BaseEndpoint
     public function update(string $generalDocumentId, array $generalDocumentData): GeneralDocument
     {
         $request = new UpdateGeneralDocumentRequest($generalDocumentId, $generalDocumentData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($generalDocumentData);
-        } else {
-            $request->body()->merge($generalDocumentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -104,12 +92,6 @@ class GeneralDocumentsEndpoint extends BaseEndpoint
     public function createAttachment(string $generalDocumentId, array $attachmentData): array
     {
         $request = new CreateGeneralDocumentAttachmentRequest($generalDocumentId, $attachmentData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($attachmentData);
-        } else {
-            $request->body()->merge($attachmentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/Documents/GeneralJournalDocuments/GeneralJournalDocumentsEndpoint.php
+++ b/src/Api/Documents/GeneralJournalDocuments/GeneralJournalDocumentsEndpoint.php
@@ -65,9 +65,6 @@ class GeneralJournalDocumentsEndpoint extends BaseEndpoint
     public function create(array $generalJournalDocumentData): GeneralJournalDocument
     {
         $request = new CreateGeneralJournalDocumentRequest($generalJournalDocumentData);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($generalJournalDocumentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -78,9 +75,6 @@ class GeneralJournalDocumentsEndpoint extends BaseEndpoint
     public function update(string $generalJournalDocumentId, array $generalJournalDocumentData): GeneralJournalDocument
     {
         $request = new UpdateGeneralJournalDocumentRequest($generalJournalDocumentId, $generalJournalDocumentData);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($generalJournalDocumentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -98,9 +92,6 @@ class GeneralJournalDocumentsEndpoint extends BaseEndpoint
     public function createAttachment(string $generalJournalDocumentId, array $attachmentData): array
     {
         $request = new CreateGeneralJournalDocumentAttachmentRequest($generalJournalDocumentId, $attachmentData);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($attachmentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/Documents/PurchaseInvoices/PurchaseInvoicesEndpoint.php
+++ b/src/Api/Documents/PurchaseInvoices/PurchaseInvoicesEndpoint.php
@@ -66,12 +66,6 @@ class PurchaseInvoicesEndpoint extends BaseEndpoint
     {
         $request = new CreatePurchaseInvoiceRequest($purchaseInvoiceData);
 
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($purchaseInvoiceData);
-        } else {
-            $request->body()->merge($purchaseInvoiceData);
-        }
-
         return $this->client->send($request)->dtoOrFail();
     }
 
@@ -81,12 +75,6 @@ class PurchaseInvoicesEndpoint extends BaseEndpoint
     public function update(string $purchaseInvoiceId, array $purchaseInvoiceData): PurchaseInvoice
     {
         $request = new UpdatePurchaseInvoiceRequest($purchaseInvoiceId, $purchaseInvoiceData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($purchaseInvoiceData);
-        } else {
-            $request->body()->merge($purchaseInvoiceData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -104,12 +92,6 @@ class PurchaseInvoicesEndpoint extends BaseEndpoint
     public function createAttachment(string $purchaseInvoiceId, array $attachmentData): array
     {
         $request = new CreatePurchaseInvoiceAttachmentRequest($purchaseInvoiceId, $attachmentData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($attachmentData);
-        } else {
-            $request->body()->merge($attachmentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/Documents/Receipts/ReceiptsEndpoint.php
+++ b/src/Api/Documents/Receipts/ReceiptsEndpoint.php
@@ -66,12 +66,6 @@ class ReceiptsEndpoint extends BaseEndpoint
     {
         $request = new CreateReceiptRequest($receiptData);
 
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($receiptData);
-        } else {
-            $request->body()->merge($receiptData);
-        }
-
         return $this->client->send($request)->dtoOrFail();
     }
 
@@ -81,12 +75,6 @@ class ReceiptsEndpoint extends BaseEndpoint
     public function update(string $receiptId, array $receiptData): Receipt
     {
         $request = new UpdateReceiptRequest($receiptId, $receiptData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($receiptData);
-        } else {
-            $request->body()->merge($receiptData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -104,12 +92,6 @@ class ReceiptsEndpoint extends BaseEndpoint
     public function createAttachment(string $receiptId, array $attachmentData): array
     {
         $request = new CreateReceiptAttachmentRequest($receiptId, $attachmentData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($attachmentData);
-        } else {
-            $request->body()->merge($attachmentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/Documents/TypelessDocuments/TypelessDocumentsEndpoint.php
+++ b/src/Api/Documents/TypelessDocuments/TypelessDocumentsEndpoint.php
@@ -66,12 +66,6 @@ class TypelessDocumentsEndpoint extends BaseEndpoint
     {
         $request = new CreateTypelessDocumentRequest($typelessDocumentData);
 
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($typelessDocumentData);
-        } else {
-            $request->body()->merge($typelessDocumentData);
-        }
-
         return $this->client->send($request)->dtoOrFail();
     }
 
@@ -81,12 +75,6 @@ class TypelessDocumentsEndpoint extends BaseEndpoint
     public function update(string $typelessDocumentId, array $typelessDocumentData): TypelessDocument
     {
         $request = new UpdateTypelessDocumentRequest($typelessDocumentId, $typelessDocumentData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($typelessDocumentData);
-        } else {
-            $request->body()->merge($typelessDocumentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -104,12 +92,6 @@ class TypelessDocumentsEndpoint extends BaseEndpoint
     public function createAttachment(string $typelessDocumentId, array $attachmentData): array
     {
         $request = new CreateTypelessDocumentAttachmentRequest($typelessDocumentId, $attachmentData);
-
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($attachmentData);
-        } else {
-            $request->body()->merge($attachmentData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/Estimates/EstimatesEndpoint.php
+++ b/src/Api/Estimates/EstimatesEndpoint.php
@@ -65,9 +65,6 @@ class EstimatesEndpoint extends BaseEndpoint
     public function create(array $estimateData): Estimate
     {
         $request = new CreateEstimateRequest($estimateData);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($estimateData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -78,9 +75,6 @@ class EstimatesEndpoint extends BaseEndpoint
     public function update(string $estimateId, array $estimateData): Estimate
     {
         $request = new UpdateEstimateRequest($estimateId, $estimateData);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($estimateData);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/ExternalSalesInvoices/ExternalSalesInvoicesEndpoint.php
+++ b/src/Api/ExternalSalesInvoices/ExternalSalesInvoicesEndpoint.php
@@ -14,11 +14,6 @@ class ExternalSalesInvoicesEndpoint extends BaseEndpoint
     public function create(array $data): ExternalSalesInvoice
     {
         $request = new CreateExternalSalesInvoiceRequest($data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -40,11 +35,6 @@ class ExternalSalesInvoicesEndpoint extends BaseEndpoint
     public function update(string $id, array $data): ExternalSalesInvoice
     {
         $request = new UpdateExternalSalesInvoiceRequest($id, $data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/FinancialMutations/FinancialMutationsEndpoint.php
+++ b/src/Api/FinancialMutations/FinancialMutationsEndpoint.php
@@ -65,9 +65,6 @@ class FinancialMutationsEndpoint extends BaseEndpoint
     public function update(string $financialMutationId, array $body): FinancialMutation
     {
         $request = new UpdateFinancialMutationRequest($financialMutationId, $body);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($body);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -78,9 +75,6 @@ class FinancialMutationsEndpoint extends BaseEndpoint
     public function linkBooking(string $financialMutationId, array $body): FinancialMutation
     {
         $request = new LinkBookingToFinancialMutationRequest($financialMutationId, $body);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($body);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/FinancialStatements/FinancialStatementsEndpoint.php
+++ b/src/Api/FinancialStatements/FinancialStatementsEndpoint.php
@@ -65,9 +65,6 @@ class FinancialStatementsEndpoint extends BaseEndpoint
     public function create(array $data): FinancialStatement
     {
         $request = new CreateFinancialStatementRequest($data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -78,9 +75,6 @@ class FinancialStatementsEndpoint extends BaseEndpoint
     public function update(string $financialStatementId, array $data): FinancialStatement
     {
         $request = new UpdateFinancialStatementRequest($financialStatementId, $data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/RecurringSalesInvoices/RecurringSalesInvoicesEndpoint.php
+++ b/src/Api/RecurringSalesInvoices/RecurringSalesInvoicesEndpoint.php
@@ -65,9 +65,6 @@ class RecurringSalesInvoicesEndpoint extends BaseEndpoint
     public function create(array $data): RecurringSalesInvoice
     {
         $request = new CreateRecurringSalesInvoiceRequest($data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }
@@ -78,9 +75,6 @@ class RecurringSalesInvoicesEndpoint extends BaseEndpoint
     public function update(string $recurringSalesInvoiceId, array $data): RecurringSalesInvoice
     {
         $request = new UpdateRecurringSalesInvoiceRequest($recurringSalesInvoiceId, $data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        }
 
         return $this->client->send($request)->dtoOrFail();
     }

--- a/src/Api/SalesInvoices/Payments/SalesInvoicePaymentsEndpoint.php
+++ b/src/Api/SalesInvoices/Payments/SalesInvoicePaymentsEndpoint.php
@@ -11,9 +11,6 @@ class SalesInvoicePaymentsEndpoint extends BaseEndpoint
     public function registerForSalesInvoiceId(string $salesInvoiceId, array $data): SalesInvoicePayment
     {
         $request = new RegisterSalesInvoicePaymentRequest($salesInvoiceId, $data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        }
         $response = $this->client->send($request);
 
         return SalesInvoicePayment::createFromResponseData($response->json());

--- a/src/Api/SalesInvoices/SalesInvoicesEndpoint.php
+++ b/src/Api/SalesInvoices/SalesInvoicesEndpoint.php
@@ -15,11 +15,6 @@ class SalesInvoicesEndpoint extends BaseEndpoint
     public function create(array $data): SalesInvoice
     {
         $request = new CreateSalesInvoiceRequest($data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
         $response = $this->client->send($request);
 
         return $request->createDtoFromResponse($response);
@@ -93,11 +88,6 @@ class SalesInvoicesEndpoint extends BaseEndpoint
     public function update(string $salesInvoiceId, array $data): SalesInvoice
     {
         $request = new UpdateSalesInvoiceRequest($salesInvoiceId, $data);
-        if (method_exists($request, 'setEncapsulatedData')) {
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
         $response = $this->client->send($request);
 
         return $request->createDtoFromResponse($response);

--- a/src/Api/Support/BaseEndpoint.php
+++ b/src/Api/Support/BaseEndpoint.php
@@ -22,21 +22,12 @@ abstract class BaseEndpoint
      */
     public function create(array $data): BaseDto
     {
-        $request = $this->getCreateRequest();
-
-        // Use setEncapsulatedData if the method exists, otherwise fall back to merge
-        /** @var object $request */
-        if (method_exists($request, 'setEncapsulatedData')) {
-            /** @var BaseJsonPostRequest|BaseJsonPatchRequest $request */
-            $request->setEncapsulatedData($data);
-        } else {
-            $request->body()->merge($data);
-        }
+        $request = $this->getCreateRequest($data);
 
         return $this->client->send($request)->dtoOrFail();
     }
 
-    protected function getCreateRequest(): ?Request
+    protected function getCreateRequest(array $data = []): ?Request
     {
         throw new \Exception('Endpoint method "create" not supported.');
     }

--- a/src/Api/Webhooks/CreateWebhookRequest.php
+++ b/src/Api/Webhooks/CreateWebhookRequest.php
@@ -12,6 +12,14 @@ class CreateWebhookRequest extends BaseJsonPostRequest
 {
     use EncapsulatesData;
 
+    public function __construct(
+        private readonly array $data = []
+    ) {
+        if (! empty($this->data)) {
+            $this->setEncapsulatedData($this->data);
+        }
+    }
+
     public function resolveEndpoint(): string
     {
         return 'webhooks';

--- a/src/Api/Webhooks/WebhooksEndpoint.php
+++ b/src/Api/Webhooks/WebhooksEndpoint.php
@@ -11,8 +11,10 @@ use Sandorian\Moneybird\Api\Support\BaseEndpoint;
  */
 class WebhooksEndpoint extends BaseEndpoint
 {
-    protected function getCreateRequest(): CreateWebhookRequest
+    protected function getCreateRequest(array $data = []): CreateWebhookRequest
     {
-        return new CreateWebhookRequest;
+        $request = new CreateWebhookRequest;
+        $request->setEncapsulatedData($data);
+        return $request;
     }
 }

--- a/src/Api/Webhooks/WebhooksEndpoint.php
+++ b/src/Api/Webhooks/WebhooksEndpoint.php
@@ -13,9 +13,6 @@ class WebhooksEndpoint extends BaseEndpoint
 {
     protected function getCreateRequest(array $data = []): CreateWebhookRequest
     {
-        $request = new CreateWebhookRequest;
-        $request->setEncapsulatedData($data);
-
-        return $request;
+        return new CreateWebhookRequest($data);
     }
 }

--- a/src/Api/Webhooks/WebhooksEndpoint.php
+++ b/src/Api/Webhooks/WebhooksEndpoint.php
@@ -15,6 +15,7 @@ class WebhooksEndpoint extends BaseEndpoint
     {
         $request = new CreateWebhookRequest;
         $request->setEncapsulatedData($data);
+
         return $request;
     }
 }


### PR DESCRIPTION
### Summary of Changes

#### Updated Request Classes with Constructors
- Added constructors to all request classes to accept `$data` parameters.
- Ensured consistent data encapsulation using `setEncapsulatedData` in constructors.
- Used proper PHP style: `! empty()` instead of `!empty()`.

#### Updated Endpoint Methods
- Modified all endpoint methods to pass data directly to request constructors.
- Removed redundant `setEncapsulatedData` calls where `$data` is passed via constructor.
- Simplified instantiations by directly returning new request instances where applicable.

#### Specific Classes Updated
- `CreateAdditionalChargeRequest`
- `CreateNoteRequest`
- `CreateContactPersonRequest`
- `UpdateContactPersonRequest`
- `CreateMbPaymentsMandateRequest`
- `CreateMbPaymentsMandateUrlRequest`
- `CreateContactRequest`
- `CreateWebhookRequest`