### PR TITLE
Make `tax_number_valid` boolean

### DIFF
--- a/src/Api/Contacts/Contact.php
+++ b/src/Api/Contacts/Contact.php
@@ -74,7 +74,7 @@ class Contact extends BaseDto
 
     public ?string $tax_number_validated_at;
 
-    public ?string $tax_number_valid;
+    public ?bool $tax_number_valid;
 
     public ?string $invoice_workflow_id;
 


### PR DESCRIPTION
The `tax_number_valid` in a Contact should be boolean (or null) instead of a string :)

```
Cannot assign false to property Sandorian\Moneybird\Api\Contacts\Contact::$tax_number_valid of type ?string
```