### PR TITLE
Fix pagination for recurring sales invoices

### DIFF
--- a/src/Api/RecurringSalesInvoices/GetRecurringSalesInvoicesRequest.php
+++ b/src/Api/RecurringSalesInvoices/GetRecurringSalesInvoicesRequest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Sandorian\Moneybird\Api\RecurringSalesInvoices;
 
 use Saloon\Http\Response;
+use Saloon\PaginationPlugin\Contracts\Paginatable;
 use Sandorian\Moneybird\Api\Support\BaseJsonGetRequest;
 
-class GetRecurringSalesInvoicesRequest extends BaseJsonGetRequest
+class GetRecurringSalesInvoicesRequest extends BaseJsonGetRequest implements Paginatable
 {
     public function resolveEndpoint(): string
     {

--- a/src/Api/Support/MoneybirdPaginator.php
+++ b/src/Api/Support/MoneybirdPaginator.php
@@ -37,7 +37,7 @@ class MoneybirdPaginator extends PagedPaginator
 
     protected function getPageItems(Response $response, Request $request): array
     {
-        return $response->json();
+        return $this->request->createDtoFromResponse($response);
     }
 
     protected function parseResponseLinks($rawLinks)

--- a/tests/Api/RecurringSalesInvoices/RecurringSalesInvoicesEndpointTest.php
+++ b/tests/Api/RecurringSalesInvoices/RecurringSalesInvoicesEndpointTest.php
@@ -46,6 +46,16 @@ class RecurringSalesInvoicesEndpointTest extends BaseTestCase
         $this->assertSame('REF-001', $recurringSalesInvoices[0]->reference);
     }
 
+    public function test_it_can_get_all_recurring_sales_invoices_paginated(): void
+    {
+        $recurringSalesInvoices = iterator_to_array($this->client->recurringSalesInvoices()->paginate()->items());
+
+        $this->assertCount(1, $recurringSalesInvoices);
+        $this->assertContainsOnlyInstancesOf(RecurringSalesInvoice::class, $recurringSalesInvoices);
+        $this->assertSame('123456789012345678', $recurringSalesInvoices[0]->id);
+        $this->assertSame('REF-001', $recurringSalesInvoices[0]->reference);
+    }
+
     public function test_it_can_get_a_recurring_sales_invoice(): void
     {
         $recurringSalesInvoice = $this->client->recurringSalesInvoices()->get('123456789012345678');


### PR DESCRIPTION
Fixes #26

I also noticed that the DTO's were not hydrated from the response when paginating which fell out when adding a test. So that was also fixed in the `MoneybirdPaginator` class. No other tests seem to start failing because of this so this is maybe not covered very well by tests at this moment.