### PR TITLE
Let `tax_number_valid` of Contact accept boolean and string

### DIFF
--- a/src/Api/Contacts/Contact.php
+++ b/src/Api/Contacts/Contact.php
@@ -74,7 +74,7 @@ class Contact extends BaseDto
 
     public ?string $tax_number_validated_at;
 
-    public ?bool $tax_number_valid;
+    public string|bool|null $tax_number_valid;
 
     public ?string $invoice_workflow_id;
 


### PR DESCRIPTION
Somehow I got an error:
```Cannot assign false to property Sandorian\Moneybird\Api\Contacts\Contact::$tax_number_valid of type ?string```

So it seems Moneybird is not really consistent.

