### PR TITLE
Let total_discount of SalesInvoice accept int and string 

### DIFF
--- a/src/Api/SalesInvoices/SalesInvoice.php
+++ b/src/Api/SalesInvoices/SalesInvoice.php
@@ -92,7 +92,7 @@ class SalesInvoice extends BaseDto
 
     public string $total_price_incl_tax_base;
 
-    public string $total_discount;
+    public string|int $total_discount;
 
     public ?string $marked_dubious_on;
 


### PR DESCRIPTION
```Cannot assign int to property Sandorian\Moneybird\Api\SalesInvoices\SalesInvoice::$total_discount of type string```

Again, it seems Moneybird is not really consistent.