### PR TITLE
Make discount property of sales invoice nullable

### DIFF
--- a/src/Api/SalesInvoices/SalesInvoice.php
+++ b/src/Api/SalesInvoices/SalesInvoice.php
@@ -52,7 +52,7 @@ class SalesInvoice extends BaseDto
 
     public string $currency;
 
-    public string $discount;
+    public ?string $discount;
 
     public ?string $original_sales_invoice_id;
 


### PR DESCRIPTION
The discount property is `null` (when no discount applied) which returns in an error.