### PR TITLE
Make draft_id property of sales invoice nullable

### DIFF
--- a/src/Api/SalesInvoices/SalesInvoice.php
+++ b/src/Api/SalesInvoices/SalesInvoice.php
@@ -32,7 +32,7 @@ class SalesInvoice extends BaseDto
 
     public string $identity_id;
 
-    public int $draft_id;
+    public ?int $draft_id;
 
     public string $state;
 


### PR DESCRIPTION
Also, `draft_id` of a sales invoice seems to be `null` when an invoice is not a draft anymore :)